### PR TITLE
Fix deps for osx-arm64

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -8,6 +8,3 @@ github:
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
-build_platform:
-  osx_arm64: osx_64
-test: native_and_emulated

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -8,3 +8,6 @@ github:
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
+build_platform:
+  osx_arm64: osx_64
+test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,7 @@ requirements:
     - python {{ python_min }}
     - setuptools
   run:
-    - olefile
-    - oletools >=0.60=*_2  # only to fix the dependencies
+    - olefile =0.47
     - python >={{ python_min }}
     - tzlocal >=4.2,<6
     - compressed-rtf >=1.0.6,<2


### PR DESCRIPTION
oletools not available for osx-arm64 and not a dependency of upstream

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
